### PR TITLE
Use Ember.Helper if available

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp"]
+  "ignore_dirs": ["tmp", "dist"]
 }

--- a/addon/helpers/number-to-human-size.js
+++ b/addon/helpers/number-to-human-size.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import makeHelper from '../utils/make-helper';
 
 export function numberToHumanSize(params/*, hash*/) {
   let bytes = params[0];
@@ -22,4 +22,4 @@ export function numberToHumanSize(params/*, hash*/) {
   return `${bytes.toFixed(roundAmount)} ${units[u]}`;
 }
 
-export default Ember.HTMLBars.makeBoundHelper(numberToHumanSize);
+export default makeHelper(numberToHumanSize);

--- a/addon/utils/make-helper.js
+++ b/addon/utils/make-helper.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default function makeHelper(helperFunction) {
+  if (Ember.Helper) {
+    return Ember.Helper.helper(helperFunction);
+  }
+  if (Ember.HTMLBars) {
+    return Ember.HTMLBars.makeBoundHelper(helperFunction);
+  }
+  return Ember.Handlebars.makeBoundHelper(helperFunction);
+}

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "ember-number-to-human-size",
   "dependencies": {
-    "ember": "1.12.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.18",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.3",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "ember": "1.13.11",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-data": "1.13.15",
+    "ember-load-initializers": "0.1.7",
+    "ember-qunit": "0.4.16",
+    "ember-qunit-notifications": "0.1.0",
+    "ember-resolver": "~0.1.20",
+    "jquery": "^1.11.3",
+    "loader.js": "ember-cli/loader.js#3.4.0",
+    "qunit": "~1.20.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 module.exports = {
   scenarios: [
     {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,7 +1,11 @@
-var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+/*jshint node:true*/
+/* global require, module */
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {});
+  var app = new EmberAddon(defaults, {
+    // Add options here
+  });
 
   /*
     This build file specifes the options for the dummy test app of this

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "ember-number-to-human-size",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember try:testall"
   },
   "repository": "",
@@ -18,28 +18,31 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.6",
-    "ember-cli-app-version": "0.3.3",
+    "broccoli-asset-rev": "^2.2.0",
+    "ember-cli": "1.13.13",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.6",
-    "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.13",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.18",
-    "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.2",
+    "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-ic-ajax": "0.2.4",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^1.2.0",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "1.13.15",
+    "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.6"
+    "ember-try": "~0.0.8"
   },
   "keywords": [
     "ember-addon",
     "number-to-human-size"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,14 +3,14 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-var App;
+let App;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+const Router = Ember.Router.extend({
   location: config.locationType
 });
 

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function destroyApp(application) {
+  Ember.run(application, 'destroy');
+}

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,0 +1,23 @@
+import { module } from 'qunit';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+export default function(name, options = {}) {
+  module(name, {
+    beforeEach() {
+      this.application = startApp();
+
+      if (options.beforeEach) {
+        options.beforeEach.apply(this, arguments);
+      }
+    },
+
+    afterEach() {
+      destroyApp(this.application);
+
+      if (options.afterEach) {
+        options.afterEach.apply(this, arguments);
+      }
+    }
+  });
+}

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
 import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,15 +1,14 @@
 import Ember from 'ember';
 import Application from '../../app';
-import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var application;
+  let application;
 
-  var attributes = Ember.merge({}, config.APP);
+  let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(function() {
+  Ember.run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/index.html
+++ b/tests/index.html
@@ -18,13 +18,14 @@
     {{content-for 'test-head-footer'}}
   </head>
   <body>
-
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
+    <script src="testem.js" integrity=""></script>
+    <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}


### PR DESCRIPTION
This PR adds a `makeHelper` util function to make a helper that's compatible with the current Ember version (based on the availability of `Ember.Helper`, `Ember.HTMLBars` or `Ember.Handlebars`).

This fixes deprecation warnings in newer versions of Ember, while maintaining compatibility with older versions.

It also updates `ember-cli` to the latest version `1.13.13`, which fixes the CI builds.
